### PR TITLE
added a trigger in db to generate embeddings using azure_openai

### DIFF
--- a/docs/workshop/docs/03-Integrate-AI-Into-PostgreSQL/05.md
+++ b/docs/workshop/docs/03-Integrate-AI-Into-PostgreSQL/05.md
@@ -121,27 +121,3 @@ Using **pgAdmin**, execute the SQL statement for each table.
     ```
 
 !!! danger "Be sure to run the `UPDATE` statements for each table to create all the embeddings before moving on to the next step."
-
-!!! info "Generate Embeddings on Database `INSERT` using a Trigger"
-
-    The code for this application performs the calls to the `azure_openai` extension to generate the vector embedding directly within the database `INSERT` command. There are times where it's more useful to use an `INSERT` trigger on the table. The trigger will automatically generate the embeddings anytime a row is inserted into table.
-
-    The following is an example of what an `INSERT` trigger for generating vector embedding on the `sow_chunks` table might look:
-
-    ```sql title="Example INSERT Trigger to Generate Embeddings"
-    -- create function that generates embeddings
-    CREATE OR REPLACE FUNCTION sow_chunks_insert_trigger_fn()
-    RETURNS trigger AS $$
-    BEGIN
-      IF NEW.content IS NOT NULL THEN
-        NEW.embeddings := azure_openai.create_embeddings('embeddings', NEW.content, throw_on_error => FALSE, max_attempts => 1000, retry_delay_ms => 2000);
-      END IF;
-      RETURN NEW;
-    END;
-    $$ LANGUAGE plpgsql;
-    -- setup INSERT TRIGGER to call function
-    CREATE TRIGGER sow_chunks_insert_trigger
-    BEFORE INSERT ON sow_chunks
-    FOR EACH ROW
-    EXECUTE FUNCTION sow_chunks_insert_trigger_fn();
-    ```

--- a/docs/workshop/docs/03-Integrate-AI-Into-PostgreSQL/06.md
+++ b/docs/workshop/docs/03-Integrate-AI-Into-PostgreSQL/06.md
@@ -1,0 +1,29 @@
+# 3.6 Add Trigger to Generate Embeddings
+
+In the previous section, we used SQL queries to generate embeddings for each table manually. In this section, we’ll enhance the `sow_chunks` table by adding a trigger function that automatically generates embeddings for the `embedding` column using `azure_openai`. This ensures that, going forward, embeddings are created automatically whenever new data is inserted into the table—eliminating the need for manual intervention.
+
+## Steps
+1. Return to the open instance of **pgAdmin** on your local machine and ensure it is connected to your PostgreSQL database.  
+2. In the pgAdmin **Object Explorer**, expand databases under your PostgreSQL server.  
+3. In the **contracts** database, right-click on the **sow_chunks** table and select **Query Tool** from the context menu.  
+4. Paste and run the following SQL code. This creates a trigger function that generates and stores a vector embedding for the text present in the `content` field during insert, using the `azure_openai.create_embedding` function.
+
+```sql
+-- create function that generates embeddings
+CREATE OR REPLACE FUNCTION sow_chunks_insert_trigger_fn()
+RETURNS trigger AS $$
+BEGIN
+  IF NEW.content IS NOT NULL THEN
+    NEW.embedding := azure_openai.create_embeddings('embeddings', NEW.content, throw_on_error => FALSE, max_attempts => 1000, retry_delay_ms => 2000);
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- setup INSERT TRIGGER to call function
+CREATE TRIGGER sow_chunks_insert_trigger
+BEFORE INSERT ON sow_chunks
+FOR EACH ROW
+EXECUTE FUNCTION sow_chunks_insert_trigger_fn();
+```
+
+With this trigger in place, your database is now equipped to automatically generate vector embeddings every time new content is added to the `sow_chunks` table. This ensures consistency, eliminates the need for manual embedding generation, and prepares your system for seamless real-time integration with applications powered by `azure_openai`.


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* When a new SOW document is uploaded and processed, its chunks are being created but the embeddings of those chunks are not. To resolve this, the following change adds a section in the docs which mandates the user to add a trigger function in the database table `sow_chunks` so that embeddings are automatically created using `azure_openai` whenever chunks are inserted into this table.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## Make the change
*  From section 3.6 of the docs, follow the instructions to add the trigger function in `sow_chunks` table of the db.


## Test the change
*  Run the application and upload a new SOW document using the UI. Once the document is processed, new entries will be added to the `sow_chunks` table.
* Check the `embedding` column of these new entries to ensure it is not NULL and that it contains the generated embeddings.


## What to Check
* Verify that the `embedding` column of the `sow_chunks` table is populated with embeddings when a new SOW document is uploaded and processed.  
