### PR TITLE
Emumba/mirza: Frontend: send meassage from home to chat automatically

### DIFF
--- a/src/userportal/src/components/CopilotChat.jsx
+++ b/src/userportal/src/components/CopilotChat.jsx
@@ -1,15 +1,15 @@
-import ReactMarkdown from "react-markdown"
-import { useState, useEffect } from "react";
+import ReactMarkdown from "react-markdown";
+import { useState, useEffect, useRef } from "react";
 import { useLocation } from "react-router-dom";
-import { Row, Col, Button,  Breadcrumb, } from "react-bootstrap"
+import { Row, Col, Button, Breadcrumb } from "react-bootstrap";
 
-import { useChatSession } from "../hooks/useChatSession"
+import { useChatSession } from "../hooks/useChatSession";
 import ChatSessions from "./chat-sessions/chat-sessions";
 import "./CopilotChat.css";
 
 const CopilotChat = () => {
   const location = useLocation();
-  
+
   const {
     sessionId,
     setSessionId,
@@ -25,98 +25,200 @@ const CopilotChat = () => {
     handleCopy,
     handleSendMessage,
     createNewSession,
-  } = useChatSession()
+  } = useChatSession();
 
-  
   const [sessionToDelete, setSessionToDelete] = useState(null);
+  // Local gate to prevent sudden UI render; show loader for first 500ms
+  const [isUiReady, setIsUiReady] = useState(false);
 
+  useEffect(() => {
+    const t = setTimeout(() => setIsUiReady(true), 500);
+    return () => clearTimeout(t);
+  }, []);
 
   useEffect(() => {
     if (messagesEndRef.current) {
-      messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
+      messagesEndRef.current.scrollIntoView({ behavior: "smooth" });
     }
   }, [messages]);
 
   //  // Handle initial message from navigation state
+  // Ensure automatic first message waits until UI is ready & hook initialized
+  const hasAutoSentRef = useRef(false);
   useEffect(() => {
+    if (hasAutoSentRef.current) return; // already sent
     const initialMessage = location.state?.initialMessage;
-    if (initialMessage && initialMessage.trim()) {
-      // Set the input and auto-trigger the message
-      setInput(initialMessage);
-      // Small delay to ensure the session is properly initialized
-      setTimeout(() => {
-        const fakeEvent = { preventDefault: () => {} };
-        handleSendMessage(fakeEvent);
-      }, 100);
-    }
-  }, [location.state]);
+    if (!initialMessage || !initialMessage.trim()) return;
+    if (!isUiReady) return; // wait until loader done
+
+    // slight delay to allow session hook state stabilization (e.g., any async side-effects)
+    const t = setTimeout(() => {
+      if (hasAutoSentRef.current) return;
+      hasAutoSentRef.current = true;
+      const fakeEvent = { preventDefault: () => {} };
+      setInput(initialMessage.trim());
+      handleSendMessage(fakeEvent, initialMessage.trim());
+    }, 1000);
+
+    return () => clearTimeout(t);
+  }, [location.state, isUiReady]);
+
+  if (!isUiReady) {
+    return (
+      <div
+        className="ai-chat d-flex align-items-center justify-content-center p-5 pt-0 m-4 mb-0"
+        style={{ minHeight: "70vh" }}
+        aria-busy={!isUiReady}
+        aria-live="polite"
+      >
+        <div
+          className="text-center"
+          role="status"
+          aria-label="Loading chat interface"
+        >
+          <div className="spinner-border text-info mb-3" />
+          <div
+            className="fw-semibold text-secondary"
+            style={{ letterSpacing: ".5px" }}
+          >
+            Initializing Chat...
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
-     <div className="ai-chat p-5 pt-0 m-4 mb-0">
-      <Row style={{ gap: '5rem' }}>
-        <Col lg={2} className='px-1' style={{"boxShadow": "0px 0px 2px 0px rgba(0, 0, 0, 0.15)", "borderRadius": "8px", "height": "82vh", overflowY: "auto", overflowX: "hidden" }}>
-         <ChatSessions sessionId={sessionId} setSessionId={setSessionId} setSessionToDelete={setSessionToDelete} messages={messages} setMessages={setMessages} sessionToDelete={sessionToDelete} setError={setError}/>
+    <div className="ai-chat p-5 pt-0 m-4 mb-0" aria-busy={isThinking}>
+      <Row style={{ gap: "5rem" }}>
+        <Col
+          lg={2}
+          className="px-1"
+          style={{
+            boxShadow: "0px 0px 2px 0px rgba(0, 0, 0, 0.15)",
+            borderRadius: "8px",
+            height: "82vh",
+            overflowY: "auto",
+            overflowX: "hidden",
+          }}
+        >
+          <ChatSessions
+            sessionId={sessionId}
+            setSessionId={setSessionId}
+            setSessionToDelete={setSessionToDelete}
+            messages={messages}
+            setMessages={setMessages}
+            sessionToDelete={sessionToDelete}
+            setError={setError}
+          />
         </Col>
         <Col lg={9}>
-        <div className='d-flex justify-content-between mb-2'>
-          <div>
-        <Breadcrumb className='mb-0'>
-      <Breadcrumb.Item href="/" >Dashboard</Breadcrumb.Item>
-      <Breadcrumb.Item active>Chats</Breadcrumb.Item>
-    </Breadcrumb>
-    <Button area-label="Back to Dashboard" alt="Back to Dashboard" href='/' variant='link' className='styled-button text-decoration-none'>
-    <i className="fa-solid fa-arrow-left"></i> Back to Dashboard
-            </Button>    
-          </div>
-    <Button area-label="New Session" alt="New Session" onClick={createNewSession} className='align-self-center'>
+          <div className="d-flex justify-content-between mb-2">
+            <div>
+              <Breadcrumb className="mb-0">
+                <Breadcrumb.Item href="/">Dashboard</Breadcrumb.Item>
+                <Breadcrumb.Item active>Chats</Breadcrumb.Item>
+              </Breadcrumb>
+              <Button
+                area-label="Back to Dashboard"
+                alt="Back to Dashboard"
+                href="/"
+                variant="link"
+                className="styled-button text-decoration-none"
+              >
+                <i className="fa-solid fa-arrow-left"></i> Back to Dashboard
+              </Button>
+            </div>
+            <Button
+              area-label="New Session"
+              alt="New Session"
+              onClick={createNewSession}
+              className="align-self-center"
+            >
               <i className="fas fa-plus"></i> New Chat
             </Button>
-        </div>
-          <div className="messages mb-3 p-3" style={{height: '65vh', overflowY: 'scroll',"boxShadow": "0px 0px 2px 0px rgba(0, 0, 0, 0.15)", "borderRadius": "8px" }}>
-
+          </div>
+          <div
+            className="messages mb-3 p-3"
+            style={{
+              height: "65vh",
+              overflowY: "scroll",
+              boxShadow: "0px 0px 2px 0px rgba(0, 0, 0, 0.15)",
+              borderRadius: "8px",
+            }}
+          >
             {messages.map((msg, index) => (
-              <div key={index} className={`message position-relative ${msg.role} mb-2 d-flex ${msg.role === 'user' ? 'justify-content-end' : 'justify-content-start'}`}>
-                    {/* Only show copy button for assistant messages */}
-            {msg.role === "assistant" && (
-              <Button
-                variant="text-primary"
-                size="sm"
-                onClick={() => handleCopy(msg.content, index)}
-                className="position-absolute top-0 end-0 m-2"
-                style={{ color: "#2979FF" }}
+              <div
+                key={index}
+                className={`message position-relative ${msg.role} mb-2 d-flex ${msg.role === "user" ? "justify-content-end" : "justify-content-start"}`}
               >
-                {copiedMessageIndex === index  ? "Copied!" : <i className="fa-regular fa-clone"></i>}
-              </Button>
-            )}
-                {!error && index === messages.length - 1 && <div ref={messagesEndRef} />}
-                <div className={`alert ${msg.role === 'user' ? 'user-message' : 'chat-response'}`} style={{ maxWidth: '90%' }} role="alert">
+                {/* Only show copy button for assistant messages */}
+                {msg.role === "assistant" && (
+                  <Button
+                    variant="text-primary"
+                    size="sm"
+                    onClick={() => handleCopy(msg.content, index)}
+                    className="position-absolute top-0 end-0 m-2"
+                    style={{ color: "#2979FF" }}
+                  >
+                    {copiedMessageIndex === index ? (
+                      "Copied!"
+                    ) : (
+                      <i className="fa-regular fa-clone"></i>
+                    )}
+                  </Button>
+                )}
+                {!error && index === messages.length - 1 && (
+                  <div ref={messagesEndRef} />
+                )}
+                <div
+                  className={`alert ${msg.role === "user" ? "user-message" : "chat-response"}`}
+                  style={{ maxWidth: "90%" }}
+                  role="alert"
+                >
                   <ReactMarkdown>{msg.content}</ReactMarkdown>
                 </div>
               </div>
             ))}
-            {error && <div className="alert alert-danger" role="alert">{error}<div ref={messagesEndRef} /></div>}
-            {isThinking && <div className="d-flex justify-content-center">
+            {error && (
+              <div className="alert alert-danger" role="alert">
+                {error}
+                <div ref={messagesEndRef} />
+              </div>
+            )}
+            {isThinking && (
+              <div className="d-flex justify-content-center">
                 <div className="spinner-border text-info" role="status">
                   <span className="visually-hidden">Thinking...</span>
                 </div>
                 <div ref={messagesEndRef} />
-              </div>}
+              </div>
+            )}
           </div>
           <div className="input-container d-flex">
-            <textarea className="form-control me-2"
+            <textarea
+              className="form-control me-2"
               value={input}
               onChange={(e) => setInput(e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter') { handleSendMessage(e); e.preventDefault(); return false; } }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  handleSendMessage(e);
+                  e.preventDefault();
+                  return false;
+                }
+              }}
               placeholder="Type a message..."
+              aria-label="Chat input"
             ></textarea>
-            <Button onClick={handleSendMessage}> <i className="fa-solid fa-paper-plane"></i></Button>
+            <Button onClick={handleSendMessage} aria-label="Send message">
+              {" "}
+              <i className="fa-solid fa-paper-plane"></i>
+            </Button>
           </div>
         </Col>
       </Row>
-
-  
     </div>
-  )
-}
+  );
+};
 
-export default CopilotChat
+export default CopilotChat;

--- a/src/userportal/src/hooks/useChatSession.jsx
+++ b/src/userportal/src/hooks/useChatSession.jsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useRef } from "react";
 import api from "../api/Api" 
 
 export const useChatSession = () => {
-  const [sessionId, setSessionId] = useState(-1);
+  const [sessionId, setSessionId] = useState(-1); // -1 indicates not yet established with backend
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState("");
   const messagesEndRef = useRef(null)
@@ -21,45 +21,47 @@ export const useChatSession = () => {
     }
   }
 
-  const handleSendMessage = async (e) => {
-      // Prevent form submission if called from form
-      if (e) {
-        e.preventDefault()
-      }
+  const inflightRef = useRef(false);
+  const suppressNextHistoryLoadRef = useRef(false); // avoids overwriting optimistic first exchange
 
-    if (input.trim() === "") return
-
-    const prompt = input;
+  const handleSendMessage = async (e, explicitMessage) => {
+    if (e) e.preventDefault();
+    const prompt = (explicitMessage ?? input).trim();
+    if (!prompt) return;
+    if (inflightRef.current) {
+      // Optionally queue or ignore; for now ignore to prevent overlap
+      return;
+    }
+    inflightRef.current = true;
     setInput("");
     setIsThinking(true);
+    setError("");
 
-    // Add the user's message to the local message history
-    const userMessage = { role: "user", content: prompt }
-    setMessages([...messages, userMessage])
-    setError("")
+    const userMessage = { role: "user", content: prompt };
+    setMessages(prev => [...prev, userMessage]);
+
     try {
-      // Get the completion from the API
-      const output = await api.completions.chat(sessionId, prompt)
-      // make sure request for a different session doesn't update the messages
-      if (sessionId === output.session_id) {
-        // Add the assistant's response to the messages
-        const assistantMessage = { role: "assistant", content: output.content }
-        setMessages([...messages, userMessage, assistantMessage])
+      // Mark to skip immediate history load if we don't yet have a server session
+      if (sessionId === -1) {
+        suppressNextHistoryLoadRef.current = true;
+      }
+      const output = await api.completions.chat(sessionId, prompt);
+      const assistantMessage = { role: "assistant", content: output.content };
+
+      // Ensure session id is updated first so future sends use correct id
+      if (sessionId === -1 || sessionId !== output.session_id) {
+        setSessionId(output.session_id);
       }
 
-      // only update the messages if the session ID is the same
-      // This keeps a processing completion from updating messages after a new session is created
-      if (sessionId === -1 || sessionId !== output.session_id) {
-        // Update the session ID
-        setSessionId(output.session_id)
-      }
-    } catch (error) {
-      console.error("Error sending message:", error)
-      setError("Error sending message. Please try again.")
+      setMessages(prev => [...prev, assistantMessage]);
+    } catch (err) {
+      console.error("Error sending message:", err);
+      setError("Error sending message. Please try again.");
     } finally {
+      inflightRef.current = false;
       setIsThinking(false);
     }
-  }
+  };
 
   const createNewSession = async () => {
     setSessionId(-1)
@@ -71,18 +73,28 @@ export const useChatSession = () => {
 
   const loadSessionHistory = async () => {
     if (!sessionId || sessionId <= 0) {
-      setMessages([])
-      return
+      setMessages([]);
+      return;
+    }
+
+    if (suppressNextHistoryLoadRef.current) {
+      // Skip the first automatic history load; let optimistic messages stand
+      suppressNextHistoryLoadRef.current = false;
+      return;
     }
 
     try {
-      const data = await api.completions.getHistory(sessionId)
-      setMessages(data)
+      const data = await api.completions.getHistory(sessionId);
+      setMessages(prev => {
+        // If backend has fewer messages (race), keep optimistic ones
+        if (data.length < prev.length) return prev;
+        return data;
+      });
     } catch (error) {
-      console.error("Error loading session history:", error)
-      setError("Error loading session history. Please try again.")
+      console.error("Error loading session history:", error);
+      setError("Error loading session history. Please try again.");
     }
-  }
+  };
 
   useEffect(() => {
     loadSessionHistory()


### PR DESCRIPTION
## Purpose
Previously, when we sent a message from the homepage input field, we were navigated to the chat page. However, the issue was that the query still remained in the chat page’s input box instead of being automatically sent to the backend.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
Test the code
- git checkout mirza/fe/chat-auto-send
- Go to the homepage
- Type a message in the chat input field
- After entering the message, you should be automatically navigated to the chat page
- If the message is sent automatically on navigation, then it’s working correctly


## Other Information

https://github.com/user-attachments/assets/ece7b816-3bbe-46d3-b50c-610f8a902164
