### PR TITLE
install node modules during devcontainer setup and add .dockerignore …

### DIFF
--- a/.devcontainer/post-create-setup.ps1
+++ b/.devcontainer/post-create-setup.ps1
@@ -29,6 +29,12 @@ Write-Host "node version: $node_version"
 $npm_version = npm --version
 Write-Host "npm version: $npm_version"
 
+# Install Frontend Node.js dependencies
+Write-Host "Installing frontend dependencies..."
+Set-Location /workspaces/postgres-sa-byoac/src/userportal
+npm install
+Write-Host "✅ Frontend dependencies installed"
+
 # Check if Docker works
 Write-Host "Checking Docker access..."
 try {

--- a/src/userportal/.dockerignore
+++ b/src/userportal/.dockerignore
@@ -1,0 +1,16 @@
+
+# Git
+.git
+.gitignore
+
+# Logs, builds, temp
+*.log
+build/
+dist/
+.vscode/
+.devcontainer/
+.idea/
+node_modules
+
+# Environments
+.env


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Added a .dockerignore file at `src/userportal` in order to avoid including `node_modules` while building the container when userportal is deployed while running `azd deploy userportal`,
* Updated `devcontainer/post-create-setup.ps1` file to run `npm install` to install frontend dependencies during devctonainer setup. These are needed to run the frontend locally.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Clone the repo, switch to this branch and build the devcontainer.

## What to Check
* Observe that `npm install` command is now run as part of the devcontainer setup and `node_modules` get installed at `src/userportal`.
* If `azd deploy userportal` is run to deploy frontend again, because of .dockerignore file we wont get node_modules error during deployment.  