### PR TITLE
Fix: Consistent List Refresh After Delete for SOWs, Vendors, and Invoices list

### DIFF
--- a/src/userportal/src/pages/invoices/list.jsx
+++ b/src/userportal/src/pages/invoices/list.jsx
@@ -34,7 +34,7 @@ const InvoiceList = () => {
       setError(null);
       setShowDeleteModal(false);
       setSowToDelete(null);
-      setReload(true); // Refresh the data
+      setReload((prev) => !prev);
     } catch (err) {
       setSuccess(null);
       setError(`Error deleting invoice: ${err.message}`);

--- a/src/userportal/src/pages/sows/list.jsx
+++ b/src/userportal/src/pages/sows/list.jsx
@@ -30,7 +30,7 @@ const SOWList = () => {
     setIsDeleting(true);
     try {
       await api.sows.delete(sowToDelete);
-      setReload(true); // Refresh the data
+      setReload((prev) => !prev);
       setError(null);
       setShowDeleteModal(false);
       setSowToDelete(null);

--- a/src/userportal/src/pages/vendors/list.jsx
+++ b/src/userportal/src/pages/vendors/list.jsx
@@ -32,7 +32,7 @@ const VendorList = () => {
       setError(null);
       setShowDeleteModal(false);
       setVendorToDelete(null);
-      setReload(true); // Refresh the data
+      setReload((prev) => !prev);
     } catch (err) {
       setSuccess(null);
       setError(`Error deleting vendor: ${err.message}`);


### PR DESCRIPTION
# Summary:
This PR addresses an issue where deleting an item (SOW, Vendor, or Invoice) from a list would only refresh the list on the first delete. Subsequent deletes did not update the UI because the reload state was not toggled, causing React to ignore the state update.

## What was changed:

- Updated the reload state logic in SOW, Vendor, and Invoice list pages to use a toggle ([setReload(prev => !prev)] instead of setting it to true after a delete.
- Ensures that every delete action triggers a state change, forcing the list to refresh and reflect the latest data.
Applied this fix consistently across SOWs, Vendors, and Invoices for a uniform user experience.

## Files affected:

- [list.jsx](invoice, sow, vendor)

## How to test:

- Delete multiple SOWs, Vendors, or Invoices in succession from their respective list pages.
- Confirm that the list refreshes and updates correctly after each delete, not just the first one.
- No stale data should remain after any delete operation.

### Notes for reviewers:

- This is a UI state management fix; no backend/API changes were made.
- The toggle approach is a common React pattern to force a re-render when the state value itself is not meaningful, only the change is.