### PR TITLE
fix(ui): include vendor_id on invoice/sow uploads + show friendly vendor validation errors

### DIFF
--- a/src/userportal/src/lib/axios.js
+++ b/src/userportal/src/lib/axios.js
@@ -47,9 +47,28 @@ axiosInstance.interceptors.response.use(
     // Handle different error scenarios
     if (error.response) {
       // Server responded with error status
-      const errorMessage = error.response.data?.detail || 
-                          error.response.data?.message || 
-                          'An error occurred';
+      const respData = error.response.data || {};
+      let errorMessage = respData?.message || 'An error occurred';
+
+      // If 'detail' is present and is an array (Pydantic style validation), format it
+      const detail = respData?.detail;
+      if (Array.isArray(detail)) {
+        // Build a readable message and attach details
+        const parts = detail.map((d) => {
+          try {
+            const loc = Array.isArray(d.loc) ? d.loc.join('.') : d.loc;
+            const msg = d.msg || JSON.stringify(d);
+            return loc ? `${loc}: ${msg}` : msg;
+          } catch (ex) {
+            return d.msg || JSON.stringify(d);
+          }
+        });
+        errorMessage = parts.join('; ');
+      } else if (typeof detail === 'string') {
+        errorMessage = detail;
+      } else if (respData?.message) {
+        errorMessage = respData.message;
+      }
       
       // Handle specific status codes
       switch (error.response.status) {
@@ -76,7 +95,10 @@ axiosInstance.interceptors.response.use(
           break;
       }
       
-      return Promise.reject(new Error(errorMessage));
+      const newErr = new Error(errorMessage);
+      // Attach original detail array if present so callers can inspect field-level errors
+      if (detail) newErr.details = detail;
+      return Promise.reject(newErr);
     } else if (error.request) {
       // Request was made but no response received
       return Promise.reject(new Error('No response from server. Please check your connection.'));

--- a/src/userportal/src/pages/invoices/create.jsx
+++ b/src/userportal/src/pages/invoices/create.jsx
@@ -72,7 +72,7 @@ const InvoiceCreate = ({ show, onHide, vendorId }) => {
       // Analyze invoice
       const result = await analyzeInvoiceMutation.mutateAsync({
         file,
-        data: { vendor_id: invoiceVendorId },
+        metadata: { vendor_id: invoiceVendorId },
       });
 
       if (result.hasError) {

--- a/src/userportal/src/pages/invoices/edit.jsx
+++ b/src/userportal/src/pages/invoices/edit.jsx
@@ -93,17 +93,27 @@ const InvoiceEdit = () => {
   const deleteMutation = useDeleteInvoice();
   const deleteLineItemMutation = useDeleteInvoiceLineItem();
 
-  // Check for query params
+  // Check for query params and clear them immediately to prevent loops
   useEffect(() => {
     const message = query.get('success');
-    if (message) {
-      setSuccess(message);
-    }
     const validation = query.get('showValidation');
-    if (validation) {
-      setShowValidation(true);
+    
+    // Only process if there are relevant params
+    if (message || validation) {
+      if (message) {
+        setSuccess(message);
+      }
+      if (validation) {
+        setShowValidation(true);
+      }
+      
+      // Clear the URL parameters immediately to prevent re-triggering
+      const url = new URL(window.location);
+      url.searchParams.delete('success');
+      url.searchParams.delete('showValidation');
+      window.history.replaceState({}, document.title, url.pathname + url.search);
     }
-  }, [query]);
+  }, []); // Empty dependency array - only run once on mount
 
   // Populate form when invoice data is loaded
   useEffect(() => {
@@ -256,6 +266,10 @@ const InvoiceEdit = () => {
     setShowValidation(false);
     setSuccess(null);
     setError(null);
+  };
+
+  const handleCloseValidationModal = () => {
+    setShowValidation(false);
   };
 
   const handleDelete = async () => {
@@ -561,8 +575,8 @@ const InvoiceEdit = () => {
 
       {showValidation && validations && validations.length > 0 && (
         <Modal
-          show={true}
-          onHide={() => setShowValidation(false)}
+          show={showValidation}
+          onHide={handleCloseValidationModal}
           centered
           size='lg'
         >
@@ -587,7 +601,7 @@ const InvoiceEdit = () => {
             <Button variant="outline-primary" onClick={onAddAnotherInvoice}>
               Add Another Invoice
             </Button>
-            <Button variant="primary" onClick={() => setShowValidation(false)}>
+            <Button variant="primary" onClick={handleCloseValidationModal}>
               View Invoice
             </Button>
           </Modal.Footer>

--- a/src/userportal/src/pages/sows/create.jsx
+++ b/src/userportal/src/pages/sows/create.jsx
@@ -72,7 +72,7 @@ const SOWCreateModal = ({ show, onHide, vendorId }) => {
 
       const result = await analyzeMutation.mutateAsync({ 
         file, 
-        data: { vendor_id: sowVendorId } 
+        metadata: { vendor_id: sowVendorId } 
       });
       
       if (result.hasError) {

--- a/src/userportal/src/pages/sows/edit.jsx
+++ b/src/userportal/src/pages/sows/edit.jsx
@@ -63,14 +63,24 @@ const SOWEdit = () => {
 
   useEffect(() => {
     const message = query.get('success');
-    if (message) {
-      setSuccess(message);
-    }
     const validation = query.get('showValidation');
-    if (validation) {
-      setShowValidation(true);
+    
+    // Only process if there are relevant params
+    if (message || validation) {
+      if (message) {
+        setSuccess(message);
+      }
+      if (validation) {
+        setShowValidation(true);
+      }
+      
+      // Clear the URL parameters immediately to prevent re-triggering
+      const url = new URL(window.location);
+      url.searchParams.delete('success');
+      url.searchParams.delete('showValidation');
+      window.history.replaceState({}, document.title, url.pathname + url.search);
     }
-  }, [useLocation().search]);
+  }, []); // Empty dependency array - only run once on mount
 
   // Update form fields when SOW data is loaded
   useEffect(() => {
@@ -255,6 +265,10 @@ const SOWEdit = () => {
     setShowValidation(false);
     setSuccess(null);
     setError(null);
+  };
+
+  const handleCloseValidationModal = () => {
+    setShowValidation(false);
   };
 
   if (isLoading) {
@@ -486,8 +500,8 @@ const SOWEdit = () => {
 
       {showValidation && validations && validations.length > 0 && (
         <Modal
-  show={true}
-  onHide={() => setShowValidation(false)}
+  show={showValidation}
+  onHide={handleCloseValidationModal}
   centered
   size='lg'
 >
@@ -512,7 +526,7 @@ const SOWEdit = () => {
      <Button variant="outline-primary" onClick={() => onAddAnotherSOW()}>
      Add Another SOW
     </Button>
-    <Button variant="primary" onClick={() => setShowValidation(false)}>
+    <Button variant="primary" onClick={handleCloseValidationModal}>
       View SOW
     </Button>
   </Modal.Footer>

--- a/src/userportal/src/pages/vendors/stepper/components/VendorDetailsStep.jsx
+++ b/src/userportal/src/pages/vendors/stepper/components/VendorDetailsStep.jsx
@@ -5,7 +5,8 @@ const VendorDetailsStep = ({
   formData, 
   setFormData, 
   error, 
-  onSave 
+  onSave,
+  serverFieldErrors = {}
 }) => {
   // Inline validation messages
   const [contactEmailError, setContactEmailError] = useState('');
@@ -109,6 +110,12 @@ const VendorDetailsStep = ({
         setContactPhoneError('');
       }
     }
+    // If server returned a field error, show it on blur as well
+    if (serverFieldErrors && serverFieldErrors[field]) {
+      if (field === 'contact_email') setContactEmailError(serverFieldErrors[field]);
+      if (field === 'contact_phone') setContactPhoneError(serverFieldErrors[field]);
+      setFieldErrors((prev) => ({ ...prev, [field]: serverFieldErrors[field] }));
+    }
   };
 
   // Helper function to check if required vendor details are filled
@@ -146,8 +153,8 @@ const VendorDetailsStep = ({
                   type="text"
                   onBlur={() => handleBlur('name')}
                 />
-                {fieldErrors.name ? (
-                  <div className="form-text text-danger mt-1">{fieldErrors.name}</div>
+                {(fieldErrors.name || serverFieldErrors.name) ? (
+                  <div className="form-text text-danger mt-1">{serverFieldErrors.name || fieldErrors.name}</div>
                 ) : null}
               </Form.Group>
             </div>
@@ -162,8 +169,8 @@ const VendorDetailsStep = ({
                 onBlur={() => handleBlur('type')}
                 required
               />
-              {fieldErrors.type ? (
-                <div className="form-text text-danger mt-1">{fieldErrors.type}</div>
+              {(fieldErrors.type || serverFieldErrors.type) ? (
+                <div className="form-text text-danger mt-1">{serverFieldErrors.type || fieldErrors.type}</div>
               ) : null}
             </div>
           </div>
@@ -182,8 +189,8 @@ const VendorDetailsStep = ({
                 onBlur={() => handleBlur('contact_name')}
                 required
               />
-              {fieldErrors.contact_name ? (
-                <div className="form-text text-danger mt-1">{fieldErrors.contact_name}</div>
+              {(fieldErrors.contact_name || serverFieldErrors.contact_name) ? (
+                <div className="form-text text-danger mt-1">{serverFieldErrors.contact_name || fieldErrors.contact_name}</div>
               ) : null}
             </div>
             <div className="col-12">
@@ -196,8 +203,8 @@ const VendorDetailsStep = ({
                 onBlur={() => handleBlur('contact_phone')}
                 required
               />
-              {contactPhoneError ? (
-                <div className="form-text text-danger mt-1">{contactPhoneError}</div>
+              {(contactPhoneError || serverFieldErrors.contact_phone) ? (
+                <div className="form-text text-danger mt-1">{serverFieldErrors.contact_phone || contactPhoneError}</div>
               ) : null}
             </div>
             <div className="col-12">
@@ -210,8 +217,8 @@ const VendorDetailsStep = ({
                 onBlur={() => handleBlur('contact_email')}
                 required
               />
-              {contactEmailError ? (
-                <div className="form-text text-danger mt-1">{contactEmailError}</div>
+              {(contactEmailError || serverFieldErrors.contact_email) ? (
+                <div className="form-text text-danger mt-1">{serverFieldErrors.contact_email || contactEmailError}</div>
               ) : null}
             </div>
             <div className="col-12">
@@ -233,8 +240,8 @@ const VendorDetailsStep = ({
                 onBlur={() => handleBlur('address')}
                 required
               />
-              {fieldErrors.address ? (
-                <div className="form-text text-danger mt-1">{fieldErrors.address}</div>
+              {(fieldErrors.address || serverFieldErrors.address) ? (
+                <div className="form-text text-danger mt-1">{serverFieldErrors.address || fieldErrors.address}</div>
               ) : null}
             </div>
           </div>

--- a/src/userportal/src/pages/vendors/stepper/stepper.jsx
+++ b/src/userportal/src/pages/vendors/stepper/stepper.jsx
@@ -25,6 +25,7 @@ const NavigationStepper = () => {
     website: "",
     address: "",
   });
+  const [serverFieldErrors, setServerFieldErrors] = useState({});
   const [vendorId, setVendorId] = useState(null);
 
   // React Query hooks
@@ -88,6 +89,7 @@ const NavigationStepper = () => {
   const handleSaveAndNext = async () => {
     setIsLoading(true);
     setError(null);
+    setServerFieldErrors({});
     try {
       // Make API calls based on current step
       switch (currentStep) {
@@ -123,10 +125,50 @@ const NavigationStepper = () => {
         window.location.href = "/vendors";
       }
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : "Something went wrong";
+      // Default fallback message
+      const rawMessage = error instanceof Error ? error.message : "Something went wrong";
       // Show error in alert for vendor details step
       if (currentStep === 0) {
-        setError(`Error: ${errorMessage}`);
+        // If the error contains details (field errors), build a friendly message
+        if (error && error.details && Array.isArray(error.details) && error.details.length > 0) {
+          const fieldErrs = {};
+          const friendlyParts = [];
+          const labelMap = {
+            contact_email: 'Email',
+            contact_phone: 'Phone',
+            contact_name: 'Contact person',
+            name: 'Vendor name',
+            type: 'Type',
+            address: 'Location',
+            website: 'Website'
+          };
+
+          error.details.forEach((d) => {
+            let field = null;
+            if (Array.isArray(d.loc) && d.loc.length >= 2) {
+              field = d.loc[1];
+            } else if (typeof d.loc === 'string') {
+              const parts = d.loc.split('.');
+              field = parts[parts.length - 1];
+            }
+
+            const msg = d.msg || (typeof d === 'string' ? d : JSON.stringify(d));
+
+            if (field) {
+              fieldErrs[field] = msg;
+              const label = labelMap[field] || field.replace(/_/g, ' ');
+              friendlyParts.push(`${label}: ${msg}`);
+            } else {
+              friendlyParts.push(msg);
+            }
+          });
+
+          setServerFieldErrors(fieldErrs);
+          setError(friendlyParts.join('; '));
+        } else {
+          // No structured details; show plain message
+          setError(rawMessage);
+        }
       }
       // Don't advance to next step if there was an error
       return;
@@ -198,6 +240,7 @@ const NavigationStepper = () => {
       formData={formData}
       setFormData={setFormData}
       error={error}
+      serverFieldErrors={serverFieldErrors}
       onSave={handleSaveAndNext}
     />,
     <SOWUploadStep


### PR DESCRIPTION
## Summary

Fixes two front-end issues causing user-facing failures:

1. **Upload Failures:** Invoice/SOW upload from vendor pages failed with a 422 error because the API expected `vendor_id` in the FormData, but the frontend was sending it incorrectly.
2. **Validation Feedback:** The vendor create form did not show clear, friendly validation feedback. Pydantic errors were surfaced as raw JSON, and the validation modal would sometimes reopen repeatedly.

## Motivation

Users can now upload Invoices and SOWs directly from the Invoices/SOWs tabs without hitting a 422 error due to a missing `vendor_id`. Additionally, when vendor creation fails due to server-side validation (invalid email, phone, etc.), users now see actionable, readable messages inline instead of raw JSON or `[object Object]` errors. This significantly improves UX and reduces support friction.

## What I Changed

* **Invoice/SOW Uploads:** Updated `create.jsx` to send `metadata: { vendor_id }` instead of `data: { vendor_id }` when calling `analyzeInvoice` and `analyzeSow` endpoints.
* **Vendor Validation UI:**
* Added client-side validation for `contact_email` (regex) and `contact_phone` (digit/char check) in `VendorDetailsStep.jsx`.
* Updated `stepper.jsx` to collect and process server-side validation `detail` arrays and map them to friendly labels.
* Passed server field errors into `VendorDetailsStep` so users see field-level feedback inline.


* **Modal Logic:** Updated `edit.jsx` to read `showValidation` and `success` query params once on mount and immediately clear them to prevent the validation modal from re-opening on re-render.
* **Error Handling:** Improved `axios.js` error formatting to convert Pydantic-style `detail` arrays into readable strings attached to `Error.details`.
* **Build Fix:** Fixed a syntax error (duplicate/stray code) in `edit.jsx` that was causing Vite/Esbuild build failures.

## Files Touched

* `create.jsx`
* `edit.jsx`
* `VendorDetailsStep.jsx`
* `stepper.jsx`
* `axios.js`

## Behavioral Changes

* **Uploads:** Invoice and SOW uploads from the vendor page now succeed (sending correct metadata) instead of returning 422.
* **Validation:** If a user submits invalid vendor data, they see specific, inline error messages (e.g., "Phone number can only contain digits...") rather than a generic failure or raw JSON.
* **Modals:** The success/validation modal no longer annoyingly re-opens after page refreshes or re-renders.

## Testing Notes

**Manual QA Steps:**

1. **Upload Test:** Navigate to a Vendor page, go to the Invoices/SOWs tab, and upload a document. Confirm it succeeds without a 422 error.
2. **Validation Test:** Attempt to create a vendor with an invalid email (e.g., missing `@`) and invalid phone characters.
* *Expected:* The form should not submit, and friendly inline error messages should appear (e.g., "Email: The part after the @-sign is not valid").


3. **Build Verification:** Ran `npm run build` in `userportal` and confirmed the build completes successfully (fixing previous syntax errors).

## Performance & Accessibility

* Validated that the frontend builds successfully (`npm run build`).
* *Note:* Observed build chunk-size warnings (> 500 kB) during the build process; this is pre-existing and out of scope for this PR, but noted for future code-splitting optimization.

## Risks & Rollback

* **Risk:** Low. Changes are isolated to vendor creation/edit forms and upload logic.
* **Rollback:** Revert to previous commit if upload functionality regresses.
