### PR TITLE
Fix: file name overflow

### DIFF
--- a/src/userportal/src/pages/sows/create.jsx
+++ b/src/userportal/src/pages/sows/create.jsx
@@ -297,7 +297,7 @@ const SOWCreateModal = ({ show, onHide, vendorId }) => {
                         📄
                       </div>
                       <div>
-                        <div className="fw-medium text-dark">{file.name}</div>
+                        <div style={{ wordBreak: "break-all" }} className="fw-medium text-dark">{file.name}</div>
                         <div className="text-muted small">
                           {formatFileSize(file.size)}
                         </div>


### PR DESCRIPTION
This pr fixes the file name overflow
<img width="698" height="624" alt="image" src="https://github.com/user-attachments/assets/d292bfa0-e4b8-479a-bdc2-1c4e1fb282b5" />
