### PR TITLE
Fix: delete SOW and Invoice documents from backend during vendor creation

### DIFF
--- a/src/userportal/src/hooks/useInvoiceUploadFlow.js
+++ b/src/userportal/src/hooks/useInvoiceUploadFlow.js
@@ -1,4 +1,4 @@
-import { useAnalyzeInvoice, useValidateInvoice } from './useInvoices';
+import { useAnalyzeInvoice, useValidateInvoice, useDeleteInvoice } from './useInvoices';
 import { getValidationResults } from '../services/invoices.service';
 import { useInvoiceUploadState } from './useInvoiceUploadState';
 import { useInvoiceErrorMapper } from './useInvoiceErrorMapper';
@@ -9,6 +9,7 @@ export const useInvoiceUploadFlow = () => {
   
   const analyzeInvoiceMutation = useAnalyzeInvoice();
   const validateInvoiceMutation = useValidateInvoice();
+  const deleteInvoiceMutation = useDeleteInvoice();
 
   const validatePreconditions = (file, vendorId, hasSOW) => {
     if (!file) {
@@ -107,6 +108,20 @@ export const useInvoiceUploadFlow = () => {
     }
   };
 
+  const clearInvoiceFile = async () => {
+    // If invoice was uploaded to backend, delete it
+    if (state.id) {
+      try {
+        await deleteInvoiceMutation.mutateAsync(state.id);
+      } catch (error) {
+        console.error('Error deleting invoice from backend:', error);
+        // Continue with clearing frontend state even if backend delete fails
+      }
+    }
+    
+    actions.clearAll();
+  };
+
   return {
     // State - mapped to original property names for compatibility
     invoiceFile: state.file,
@@ -122,7 +137,7 @@ export const useInvoiceUploadFlow = () => {
     // Actions - mapped to original method names
     setInvoiceFile: actions.setFile,
     uploadInvoice,
-    clearInvoiceFile: actions.clearAll,
+    clearInvoiceFile: clearInvoiceFile,
     clearInvoiceErrors: actions.clearErrors,
   };
 };

--- a/src/userportal/src/hooks/useSOWUpload.js
+++ b/src/userportal/src/hooks/useSOWUpload.js
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useAnalyzeSOW, useValidateSOW } from './useSOWs';
+import { useAnalyzeSOW, useValidateSOW, useDeleteSOW } from './useSOWs';
 import { getValidationResults } from '../services/sows.service';
 
 export const useSOWUpload = () => {
@@ -14,6 +14,7 @@ export const useSOWUpload = () => {
 
   const analyzeSOWMutation = useAnalyzeSOW();
   const validateSOWMutation = useValidateSOW();
+  const deleteSOWMutation = useDeleteSOW();
 
   const clearErrors = () => {
     setError(null);
@@ -22,7 +23,17 @@ export const useSOWUpload = () => {
     setSuccess(null);
   };
 
-  const clearFile = () => {
+  const clearFile = async () => {
+    // If SOW was uploaded to backend, delete it
+    if (sowId) {
+      try {
+        await deleteSOWMutation.mutateAsync(sowId);
+      } catch (error) {
+        console.error('Error deleting SOW from backend:', error);
+        // Continue with clearing frontend state even if backend delete fails
+      }
+    }
+    
     setSowFile(null);
     setSowId(null);
     setError(null);


### PR DESCRIPTION
### **Description**

This PR addresses an issue in the vendor creation stepper flow where removing uploaded documents (SOW and Invoice) only cleared the frontend state. Previously, the actual files remained in the database and blob storage, resulting in orphaned records and wasted storage space.

The upload hooks have been modified to trigger backend delete APIs when a user removes a document via the UI.

### **Key Changes**

**SOW Upload (`useSOWUpload.js`)**

* Imported `useDeleteSOW` hook.
* Refactored `clearFile()` to be asynchronous.
* Implemented logic to call the backend delete endpoint before clearing the frontend state.
* Added error handling to ensure the UI still clears the file even if the backend deletion fails (preserving good UX).

**Invoice Upload (`useInvoiceUploadFlow.js`)**

* Imported `useDeleteInvoice` hook.
* Added `deleteInvoiceMutation` to the hook setup.
* *Note: The async implementation for `clearInvoiceFile` is currently in progress.*

### **Type of Change**

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Refactor (code improvement/cleanup)

### **Testing Instructions**

1. **SOW Flow:**
* Go to the Vendor Creation flow.
* Upload an SOW document.
* Click the remove/delete icon.
* **Verify:** The file is removed from the UI.
* **Verify:** A network request is sent to the backend delete API.
* **Verify:** The record is removed from the database/blob storage.


2. **Invoice Flow:**
* *(Once implementation is complete)* Repeat the steps above for the Invoice document.


3. **Error Handling:**
* Simulate a backend error during deletion.
* Verify that the file is still removed from the UI so the user is not blocked.
